### PR TITLE
Restore missing packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         package_dir={'': 'src'},
         include_package_data=True,
         install_requires=[
-            "setuptools",
+            "packaging>=18.0",
             "coreapi>=2.3.3",
             "coreschema>=0.0.4",
             "django>=1.1.0",


### PR DESCRIPTION
Closes #36 

This package has a hard requirement on `packaging` and as such needs to add it to its requirements.

https://github.com/JoelLefkowitz/drf-yasg/blob/32d7a63c1d7ca7d1904871550a71fb3bac38a6cf/src/drf_yasg2/generators.py#L9

`setuptools` is only required to build the package, not run it, so it should not be included in the requirements. Source distributions are already covered by:

https://github.com/JoelLefkowitz/drf-yasg/blob/32d7a63c1d7ca7d1904871550a71fb3bac38a6cf/pyproject.toml#L2