### PR TITLE
Add support for Python 3.9 & Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       script: scripts/tox-filter.sh py38
 
     - <<: *unittest
-      python: 3.9
+      python: 3.9-dev
       script: scripts/tox-filter.sh py39
 
     # This tests readthedocs will be able to build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ jobs:
       python: 3.8
       script: scripts/tox-filter.sh py38
 
+    - <<: *unittest
+      python: 3.9
+      script: scripts/tox-filter.sh py39
+
     # This tests readthedocs will be able to build
     - stage: test-docs
       script: scripts/docs.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
     Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Topic :: Documentation
     Topic :: Software Development :: Code Generators
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 
 envlist =
     py27-django111-drf{38,39},
-    py{36,37,38}-django{22,30}-drf{38,39,310,311,312},
+    py{36,37,38,39}-django{22,30}-drf{38,39,310,311,312},
     py38-django_latest-drf_latest,
 
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,14 @@ skip_missing_interpreters = true
 
 envlist =
     py27-django111-drf{38,39},
-    py{36,37,38,39}-django{22,30}-drf{38,39,310,311,312},
+    py{36,37,38,39}-django{22,30,31}-drf{38,39,310,311,312},
     py38-django_latest-drf_latest,
 
 deps =
     django111: Django>=1.11<2.0
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.0,<3.1
     django_latest: https://github.com/django/django/archive/master.tar.gz
     django_latest: https://github.com/ottoyiu/django-cors-headers/archive/master.tar.gz
 


### PR DESCRIPTION
Closes #11 

Rebased #14

- Add Python 3.9 testing
- Add support for Django 3.1