### PR TITLE
Fix 'an integer is required' in 'generate_swagger'

### DIFF
--- a/src/drf_yasg2/management/commands/generate_swagger.py
+++ b/src/drf_yasg2/management/commands/generate_swagger.py
@@ -185,5 +185,5 @@ class Command(BaseCommand):
         if output_file == "-":
             self.write_schema(schema, self.stdout, format)
         else:
-            with os.open(output_file, "w") as stream:
+            with open(output_file, "w") as stream:
                 self.write_schema(schema, stream, format)


### PR DESCRIPTION
My CI raise following error when attempt to upgrade (see pull watchdogpolska/small_eod#669 ):
```
Traceback (most recent call last):
  File "manage.py", line 21, in <module>
    main()
  File "manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/drf_yasg2/management/commands/generate_swagger.py", line 188, in handle
    with os.open(output_file, "w") as stream:
TypeError: an integer is required (got type str)
Makefile:36: recipe for target 'test_openapi_spec' failed
```
Full logs available at: https://github.com/watchdogpolska/small_eod/pull/669/checks?check_run_id=1269280555

Python have built-in `open` and `os.open`. `os.open` require numeric-flags ( see https://docs.python.org/3/library/os.html#os.open ) and built-in `open` use string-flag (see https://docs.python.org/3/library/functions.html#open ). 

See also following:
```
$ python3 -c "import os; open('/dev/null','w')"
$ python3 -c "import os; os.open('/dev/null','w')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: an integer is required (got type str)
$ python2 -c "import os; os.open('/dev/null','w')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: an integer is required
```