### PR TITLE
Update urlpatterns to use path and re_path instead of deprecated url

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Add the package to INSTALLED_APPS:
 Add the endpoints to urlpatterns:
 
 ```python
-
+   
+   from django.urls import path, re_path
    from rest_framework import permissions
    from drf_yasg2.views import get_schema_view
    from drf_yasg2 import openapi
@@ -105,9 +106,9 @@ Add the endpoints to urlpatterns:
    )
 
    urlpatterns = [
-      url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-      url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-      url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+      re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+      path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+      path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
       ...
    ]
 ```


### PR DESCRIPTION
Update `urlpatterns` to use [`path`](https://docs.djangoproject.com/en/3.1/ref/urls/#path) and [`re_path`](https://docs.djangoproject.com/en/3.1/ref/urls/#re-path) since [`url` is deprecated in django 3.1](https://docs.djangoproject.com/en/3.1/ref/urls/#url).