### PR TITLE
Restore instructions for integration with drf-extra-fields

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ drf-yasg2
    custom_spec.rst
    custom_ui.rst
    settings.rst
+   third_party_integrations.rst
    contributing.rst
    license.rst
    changelog.rst

--- a/docs/third_party_integrations.rst
+++ b/docs/third_party_integrations.rst
@@ -1,0 +1,33 @@
+########################
+Third Party Integrations
+########################
+
+****************
+drf-extra-fields
+****************
+
+Integration with `drf-extra-fields <https://github.com/Hipo/drf-extra-fields>`_ has a problem
+with Base64 fields. By default, ``drf-yasg2`` will generate Base64 file or image fields as
+Readonly and not required in the OpenAPI schema. Here is a workaround to mark required Base64
+fields correctly.
+
+.. code:: python
+
+    class PDFBase64FileField(Base64FileField):
+        ALLOWED_TYPES = ['pdf']
+
+        class Meta:
+            swagger_schema_fields = {
+                'type': 'string',
+                'title': 'File Content',
+                'description': 'Content of the file base64 encoded',
+                'read_only': False  # <-- FIX
+            }
+
+        def get_file_extension(self, filename, decoded_file):
+            try:
+                PyPDF2.PdfFileReader(io.BytesIO(decoded_file))
+            except PyPDF2.utils.PdfReadError as e:
+                logger.warning(e)
+            else:
+                return 'pdf'


### PR DESCRIPTION
#29 says it fixes this issue but it seems that somewhere along the line this was lost.

Rather than clutter the README with this information, I created a new page in the docs.

Cross references:

- https://github.com/axnsan12/drf-yasg/pull/445
- https://github.com/Hipo/drf-extra-fields/pull/100
- https://github.com/Hipo/drf-extra-fields/issues/66
- https://github.com/Hipo/drf-extra-fields#drf-yasg-fix-for-base64-fields